### PR TITLE
Revert "Remove typescript since repository contributors don't master it"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10865,6 +10865,12 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
+    "typescript": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+      "dev": true
+    },
     "ua-parser-js": {
       "version": "0.7.21",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "jest-expo": "^36.0.1",
     "lint-staged": "^10.0.8",
     "prettier": "^1.19.1",
-    "react-test-renderer": "^16.13.1"
+    "react-test-renderer": "^16.13.1",
+    "typescript": "^3.8.3"
   },
   "lint-staged": {
     "**/*.{js,jsx,css}": [


### PR DESCRIPTION
Reverts UltimateApp/UltimateApp#46

It looks like eslint needs typescript to work.

We get errors on pre-commit hooks :

```zsh
➜  UltimateApp git:(technical-drills-filter) ✗ git commit -m tmp
husky > pre-commit (node v10.15.3)
  ✔ Preparing...
  ❯ Running tasks...
    ❯ Running tasks for **/*.{js,jsx,css}
      ✖ npm run lint-fix
        npm run prettier-fix
  ↓ Applying modifications... [skipped]
    → Skipped because of errors from tasks.
  ✔ Reverting to original state...
  ✔ Cleaning up...



✖ npm found some errors. Please fix them and try committing again.

> @ lint-fix /Users/sallesma/code/perso/UltimateApp
> eslint src --fix --ext .js,.jsx "/Users/sallesma/code/perso/UltimateApp/src/Components/HomePage.js"

Error: Failed to load plugin '@typescript-eslint' declared in '.eslintrc.js » eslint-config-universe/native » ./shared/typescript.js': Cannot find module 'typescript'
  at Function.Module._resolveFilename (internal/modules/cjs/loader.js:582:15)
  at Function.Module._load (internal/modules/cjs/loader.js:508:25)
  at Module.require (internal/modules/cjs/loader.js:637:17)
  at require (/Users/sallesma/code/perso/UltimateApp/node_modules/v8-compile-cache/v8-compile-cache.js:161:20)
  at Object.<anonymous> (/Users/sallesma/code/perso/UltimateApp/node_modules/tsutils/typeguard/2.8/node.js:3:12)
  at Module._compile (/Users/sallesma/code/perso/UltimateApp/node_modules/v8-compile-cache/v8-compile-cache.js:194:30)
  at Object.Module._extensions..js (internal/modules/cjs/loader.js:712:10)
  at Module.load (internal/modules/cjs/loader.js:600:32)
  at tryModuleLoad (internal/modules/cjs/loader.js:539:12)
  at Function.Module._load (internal/modules/cjs/loader.js:531:3)
npm ERR! code ELIFECYCLE
npm ERR! errno 2
npm ERR! @ lint-fix: `eslint src --fix --ext .js,.jsx "/Users/sallesma/code/perso/UltimateApp/src/Components/HomePage.js"`
npm ERR! Exit status 2
npm ERR!
npm ERR! Failed at the @ lint-fix script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/sallesma/.npm/_logs/2020-04-01T16_53_48_588Z-debug.log
husky > pre-commit hook failed (add --no-verify to bypass)
```

Which are fixed with `npm install --save-dev typescript`

Therefore I think we must rollback this pull-request